### PR TITLE
feat: return documents' title instead of documents' content

### DIFF
--- a/backend/app/api/routes/templates.py
+++ b/backend/app/api/routes/templates.py
@@ -1,18 +1,18 @@
+import json
 import os
+import re
 import sys
 from datetime import datetime
 from typing import Dict
-import json
-import re
 
 from db import models
 from db.database import get_db
-from db.models import PromptAns, HashTag, PromptAns_HashTag
+from db.models import HashTag, PromptAns, PromptAns_HashTag
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 from retrieval.rag import retrieve_doc
-from sqlalchemy.orm import Session
 from sqlalchemy import insert
+from sqlalchemy.orm import Session
 from utils.gpt import gpt_genereate
 
 sys.path.append(os.path.dirname(os.path.abspath(os.path.dirname(__file__))))
@@ -108,7 +108,7 @@ async def create_template(prompt: Prompt, db: Session = Depends(get_db)):
             embedding=app_main.embedding,
             llm=app_main.llm,
         )
-        result, documents_list = gpt_genereate(
+        result, document_title_list = gpt_genereate(
             instruction=prompt, retrieved_doc=retrieved_doc
         )
 
@@ -135,7 +135,7 @@ async def create_template(prompt: Prompt, db: Session = Depends(get_db)):
             prompt=prompt,
             template=template_file,
             description=description,
-            documents=documents_dummy,
+            documents=document_title_list,
             # user_id=user_id,
         )
         db.add(db_promptAns)

--- a/backend/app/utils/gpt.py
+++ b/backend/app/utils/gpt.py
@@ -27,9 +27,9 @@ def gpt_genereate(instruction: str, retrieved_doc: List[dict]):
     )
 
     response = completion.choices[0].message.content
-    doc_list = [doc.page_content for doc in retrieved_doc]
+    doc_title_list = [doc.metadata["title"] for doc in retrieved_doc]
 
-    return response, doc_list
+    return response, doc_title_list
 
 
 def gpt_generate_no_rag(instruction: str):


### PR DESCRIPTION
- 벡터 데이터베이스의 메타데이터에 문서의 제목을 포함하도록 변경
- 멀티 쿼리를 통해 검색한 관련 문서의 내용을 반환했던 것에서 관련 문서의 제목을 반환하도록 변경